### PR TITLE
Fix Unwrap Not Consuming Closing Token

### DIFF
--- a/parser.go
+++ b/parser.go
@@ -143,11 +143,12 @@ func (parser *Parser) Unwrap(enc Enclosure) (string, error) {
 			return "", fmt.Errorf("missing end of enclosure: '%v'", string(enc.stop))
 		}
 
+		parser.Advance()
+
 		if nesting == 0 {
 			// If nesting is resolved, slice input and return
-			return parser.scanner.collectBetween(start, parser.curr.Position), nil
+			// The stop point is 1 position before enclose closer
+			return parser.scanner.collectBetween(start, parser.curr.Position-1), nil
 		}
-
-		parser.Advance()
 	}
 }

--- a/parser_test.go
+++ b/parser_test.go
@@ -45,50 +45,53 @@ func TestParser_Unwrap(t *testing.T) {
 	}
 
 	tests := []struct {
-		input   string
-		options []ParserOption
-		enclose Enclosure
-		output  string
-		error   string
+		input    string
+		options  []ParserOption
+		enclose  Enclosure
+		output   string
+		error    string
+		unparsed string
 	}{
 		{
-			"[string]", nil,
-			EnclosureSquare(), "string", "",
+			"[string]", nil, EnclosureSquare(),
+			"string", "", "",
 		},
 		{
-			"{map[string]string}", nil,
-			EnclosureCurly(), "map[string]string", "",
+			"{map[string]string}", nil, EnclosureCurly(),
+			"map[string]string", "", "",
 		},
 		{
-			"< mycroft  holmes >", []ParserOption{IgnoreWhitespaces()},
-			EnclosureAngle(), " mycroft  holmes ", "",
+			"< mycroft  holmes >", []ParserOption{IgnoreWhitespaces()}, EnclosureAngle(),
+			" mycroft  holmes ", "", "",
 		},
 		{
-			"@sarah[chapman&", nil,
-			mustEnclose(NewEnclosure('@', '&')), "sarah[chapman", "",
+			"@sarah[chapman&", nil, mustEnclose(NewEnclosure('@', '&')),
+			"sarah[chapman", "", "",
 		},
 		{
-			"( 12345(555))", []ParserOption{IgnoreWhitespaces()},
-			EnclosureParens(), " 12345(555)", "",
+			"( 12345(555))hello123", []ParserOption{IgnoreWhitespaces()}, EnclosureParens(),
+			" 12345(555)", "", "hello123",
 		},
 		{
-			"map(sequence[map])", nil,
-			EnclosureParens(), "", "missing start of enclosure: '('",
+			"map(sequence[map])", nil, EnclosureParens(),
+			"", "missing start of enclosure: '('", "map(sequence[map])",
 		},
 		{
-			"(map(sequence[map]", nil,
-			EnclosureParens(), "", "missing end of enclosure: ')'",
+			"(map(sequence[map]", nil, EnclosureParens(),
+			"", "missing end of enclosure: ')'", "",
 		},
 	}
 
 	for _, test := range tests {
 		parser := NewParser(test.input, test.options...)
 		unwrapped, err := parser.Unwrap(test.enclose)
-		assert.Equal(t, test.output, unwrapped)
+		assert.Equal(t, test.output, unwrapped, "Unwrapped Data Check")
 
 		if test.error != "" {
-			assert.EqualError(t, err, test.error)
+			assert.EqualError(t, err, test.error, "Error Check")
 		}
+
+		assert.Equal(t, test.unparsed, parser.Unparsed(), "Unparsed Data Check")
 	}
 }
 


### PR DESCRIPTION
- parser.Unwrap method did not correct consume the enclose closing token. This has been resolved by checking the nesting resolution AFTER advancing the cursor for that iteration.
- This means the position of the parser when returning enclosed data is after the close token so the position for slicing must be decremented to account for that.
- Update parser tests for unwrap to also check the unparsed data after unwrapping to make sure that end tokens are correctly consumed